### PR TITLE
Add support for filtering using multi-field indexes correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,10 +86,29 @@ function fixIndexSupport(index) {
     }
 
     function testValue(v) {
-      return (((!r.lowerOpen && v >= r.lower) || (r.lowerOpen && v > r.lower)) && ((!r.upperOpen && v <= r.upper) || (r.upperOpen && v < r.upper))
-        || (r.upper === undefined && ((!r.lowerOpen && v >= r.lower) || (r.lowerOpen && v > r.lower)))
-        || (r.lower === undefined && ((!r.upperOpen && v <= r.upper) || (r.upperOpen && v < r.upper))));
+      if (Array.isArray(v)) {
+        var i;
+        vLength = v.length;
+        for (i = 0; i < vLength; i++) {
+          if (!testAgainst(getIfArray(r.lower, i), r.lowerOpen, getIfArray(r.upper, i), r.upperOpen, v[i])) return false;
+        }
+        return true;
+      } else {
+        return testAgainst(r.lower, r.lowerOpen, r.upper, r.upperOpen, v);
+      }
     }
+
+    function testAgainst(lower, lowerOpen, upper, upperOpen, v) {
+      return (((!lowerOpen && v >= lower) || (lowerOpen && v > lower)) && ((!upperOpen && v <= upper) || (upperOpen && v < upper))
+        || (upper === undefined && ((!lowerOpen && v >= lower) || (lowerOpen && v > lower)))
+        || (lower === undefined && ((!upperOpen && v <= upper) || (upperOpen && v < upper))));
+    }
+
+    function getIfArray(arr, i) {
+      if (!Array.isArray(arr)) return undefined;
+      return arr[i];
+    }
+
   };
 
   index.count = function count(key, cb) {


### PR DESCRIPTION
After becoming more familiar with the way treo emulates IndexedDB using WebSQL I realised that it's probably not feasible to do a proper query when filtering by index with a KeyRange with multiple fields. 

I've taken a pass at fixing the `testValue` function to allow for KeyRanges with multiple fields. I wasn't sure how you run your tests for treo-websql as I assume it doesn't get used when running in PhantomJS. For what it's worth the test suite still passes with this change though as I say, I suspect it's not being used.
